### PR TITLE
Non case sensitive

### DIFF
--- a/tests/test_word_tokenize.py
+++ b/tests/test_word_tokenize.py
@@ -6,31 +6,77 @@ SENTENCE1 = '吾輩は猫である'
 
 
 class WordTokenizerTest(unittest.TestCase):
+    """Test ordinal word tokenizer."""
+
     def test_word_tokenize_with_kytea(self):
+        """Test KyTea tokenizer."""
         tokenizer = WordTokenizer('KyTea')
         expect = '吾輩 は 猫 で あ る'
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
     def test_word_tokenize_with_mecab(self):
+        """Test MeCab tokenizer."""
         tokenizer = WordTokenizer('MeCab')
         expect = '吾輩 は 猫 で ある'
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
     def test_word_tokenize_with_sentencepiece(self):
+        """Test Sentencepiece tokenizer."""
         tokenizer = WordTokenizer('Sentencepiece', 'data/model.spm')
         expect = '▁ 吾 輩 は 猫 である'
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
     def test_word_tokenize_with_character(self):
+        """Test Character tokenizer."""
         tokenizer = WordTokenizer('Character')
         expect = '吾 輩 は 猫 で あ る'
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
     def test_word_without_tokenizer(self):
+        """Test identity tokenizer."""
+        tokenizer = WordTokenizer()
+        expect = '吾輩は猫である'
+        result = tokenizer.tokenize(SENTENCE1)
+        self.assertEqual(expect, result)
+
+
+class WordTokenizerWithLowerCaseTest(unittest.TestCase):
+    """Test ordinal word tokenizer."""
+
+    def test_word_tokenize_with_kytea(self):
+        """Test KyTea tokenizer."""
+        tokenizer = WordTokenizer('kytea')
+        expect = '吾輩 は 猫 で あ る'
+        result = tokenizer.tokenize(SENTENCE1)
+        self.assertEqual(expect, result)
+
+    def test_word_tokenize_with_mecab(self):
+        """Test MeCab tokenizer."""
+        tokenizer = WordTokenizer('mecab')
+        expect = '吾輩 は 猫 で ある'
+        result = tokenizer.tokenize(SENTENCE1)
+        self.assertEqual(expect, result)
+
+    def test_word_tokenize_with_sentencepiece(self):
+        """Test Sentencepiece tokenizer."""
+        tokenizer = WordTokenizer('sentencepiece', 'data/model.spm')
+        expect = '▁ 吾 輩 は 猫 である'
+        result = tokenizer.tokenize(SENTENCE1)
+        self.assertEqual(expect, result)
+
+    def test_word_tokenize_with_character(self):
+        """Test Character tokenizer."""
+        tokenizer = WordTokenizer('character')
+        expect = '吾 輩 は 猫 で あ る'
+        result = tokenizer.tokenize(SENTENCE1)
+        self.assertEqual(expect, result)
+
+    def test_word_without_tokenizer(self):
+        """Test identity tokenizer."""
         tokenizer = WordTokenizer()
         expect = '吾輩は猫である'
         result = tokenizer.tokenize(SENTENCE1)


### PR DESCRIPTION
In this PR, I update WordTokenizer so that it accepts lowercased names of tokenizers.
(For example, `tokenizer = WordTokenizer('kytea')` )
