### PR TITLE
Add token class

### DIFF
--- a/example/tokenize_demo.py
+++ b/example/tokenize_demo.py
@@ -5,11 +5,10 @@ from tiny_tokenizer import WordTokenizer
 if __name__ == "__main__":
     sentence_tokenizer = SentenceTokenizer()
     word_tokenizers = []
-    word_tokenizers.append(WordTokenizer())  # return input directly
-    word_tokenizers.append(WordTokenizer("MeCab"))
-    word_tokenizers.append(WordTokenizer("KyTea"))
-    word_tokenizers.append(WordTokenizer("Sentencepiece", "data/model.spm"))
-    word_tokenizers.append(WordTokenizer("Character"))
+    word_tokenizers.append(WordTokenizer(tokenizer="MeCab"))
+    word_tokenizers.append(WordTokenizer(tokenizer="KyTea"))
+    word_tokenizers.append(WordTokenizer(tokenizer="Sentencepiece", model_path="data/model.spm"))  # NOQA
+    word_tokenizers.append(WordTokenizer(tokenizer="Character"))
     print("Finish creating word tokenizers")
     print()
 
@@ -22,6 +21,6 @@ if __name__ == "__main__":
 
         for tokenizer in word_tokenizers:
             result = tokenizer.tokenize(sentence)
-            print(f"Tokenizer ({tokenizer.tokenizer_name}): {result}")
+            print(f"Tokenizer ({tokenizer.name}): {result}")
 
         print()

--- a/example/tokenize_demo.py
+++ b/example/tokenize_demo.py
@@ -6,7 +6,9 @@ if __name__ == "__main__":
     sentence_tokenizer = SentenceTokenizer()
     word_tokenizers = []
     word_tokenizers.append(WordTokenizer(tokenizer="MeCab"))
+    word_tokenizers.append(WordTokenizer(tokenizer="MeCab", with_postag=True))
     word_tokenizers.append(WordTokenizer(tokenizer="KyTea"))
+    word_tokenizers.append(WordTokenizer(tokenizer="KyTea", with_postag=True))
     word_tokenizers.append(WordTokenizer(tokenizer="Sentencepiece", model_path="data/model.spm"))  # NOQA
     word_tokenizers.append(WordTokenizer(tokenizer="Character"))
     print("Finish creating word tokenizers")

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
 """setup.py."""
 
+from os import getenv
 
 from setuptools import find_packages
 from setuptools import setup
 
-from os import getenv
-
 
 try:
-    BUILD_WORD_TOKENIZER = int(getenv("BUILD_WORD_TOKENIZER", 1))
-except:
+    BUILD_WORD_TOKENIZER = int(getenv("BUILD_WORD_TOKENIZER", '1'))
+except ValueError:
     raise ValueError("BUILD_WORD_TOKENIZER should be integer")
 
 
@@ -22,7 +21,7 @@ else:
 
 setup(
     name="tiny_tokenizer",
-    version="1.3.1",
+    version="2.0.0",
     description="Tiny Word/Sentence Tokenizer",
     author="himkt",
     author_email="himkt@klis.tsukuba.ac.jp",

--- a/tests/test_word_tokenize.py
+++ b/tests/test_word_tokenize.py
@@ -1,7 +1,9 @@
-from tiny_tokenizer.word_tokenizer import WordTokenizer
-
+"""Test for word tokenizers"""
 import unittest
 import pytest
+
+from tiny_tokenizer.word_tokenizer import WordTokenizer
+from tiny_tokenizer.word_tokenizer import Token
 
 
 SENTENCE1 = "吾輩は猫である"
@@ -17,7 +19,7 @@ class WordTokenizerTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip kytea")
 
-        expect = "吾輩 は 猫 で あ る".split(" ")
+        expect = [Token(surface=w) for w in "吾輩 は 猫 で あ る".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -28,7 +30,7 @@ class WordTokenizerTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip mecab")
 
-        expect = "吾輩 は 猫 で ある".split(" ")
+        expect = [Token(surface=w) for w in "吾輩 は 猫 で ある".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -42,7 +44,7 @@ class WordTokenizerTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip sentencepiece")
 
-        expect = "▁ 吾 輩 は 猫 である".split(" ")
+        expect = [Token(surface=w) for w in "▁ 吾 輩 は 猫 である".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -51,7 +53,7 @@ class WordTokenizerTest(unittest.TestCase):
         tokenizer = WordTokenizer(
             tokenizer="Character"
         )
-        expect = "吾 輩 は 猫 で あ る".split(" ")
+        expect = [Token(surface=w) for w in "吾 輩 は 猫 で あ る".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -66,7 +68,7 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip kytea")
 
-        expect = "吾輩 は 猫 で あ る".split(" ")
+        expect = [Token(surface=w) for w in "吾輩 は 猫 で あ る".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -77,7 +79,7 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip mecab")
 
-        expect = "吾輩 は 猫 で ある".split(" ")
+        expect = [Token(surface=w) for w in "吾輩 は 猫 で ある".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -91,13 +93,13 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
         except ModuleNotFoundError:
             pytest.skip("skip sentencepiece")
 
-        expect = "▁ 吾 輩 は 猫 である".split(" ")
+        expect = [Token(surface=w) for w in "▁ 吾 輩 は 猫 である".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
     def test_word_tokenize_with_character(self):
         """Test Character tokenizer."""
         tokenizer = WordTokenizer(tokenizer="character")
-        expect = "吾 輩 は 猫 で あ る".split(" ")
+        expect = [Token(surface=w) for w in "吾 輩 は 猫 で あ る".split(" ")]
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)

--- a/tests/test_word_tokenize.py
+++ b/tests/test_word_tokenize.py
@@ -13,7 +13,7 @@ class WordTokenizerTest(unittest.TestCase):
     def test_word_tokenize_with_kytea(self):
         """Test KyTea tokenizer."""
         try:
-            tokenizer = WordTokenizer("KyTea")
+            tokenizer = WordTokenizer(tokenizer="KyTea")
         except ModuleNotFoundError:
             pytest.skip("skip kytea")
 
@@ -24,7 +24,7 @@ class WordTokenizerTest(unittest.TestCase):
     def test_word_tokenize_with_mecab(self):
         """Test MeCab tokenizer."""
         try:
-            tokenizer = WordTokenizer("MeCab")
+            tokenizer = WordTokenizer(tokenizer="MeCab")
         except ModuleNotFoundError:
             pytest.skip("skip mecab")
 
@@ -35,7 +35,10 @@ class WordTokenizerTest(unittest.TestCase):
     def test_word_tokenize_with_sentencepiece(self):
         """Test Sentencepiece tokenizer."""
         try:
-            tokenizer = WordTokenizer("Sentencepiece", "data/model.spm")
+            tokenizer = WordTokenizer(
+                tokenizer="Sentencepiece",
+                model_path="data/model.spm"
+            )
         except ModuleNotFoundError:
             pytest.skip("skip sentencepiece")
 
@@ -45,15 +48,10 @@ class WordTokenizerTest(unittest.TestCase):
 
     def test_word_tokenize_with_character(self):
         """Test Character tokenizer."""
-        tokenizer = WordTokenizer("Character")
+        tokenizer = WordTokenizer(
+            tokenizer="Character"
+        )
         expect = "吾 輩 は 猫 で あ る".split(" ")
-        result = tokenizer.tokenize(SENTENCE1)
-        self.assertEqual(expect, result)
-
-    def test_word_without_tokenizer(self):
-        """Test identity tokenizer."""
-        tokenizer = WordTokenizer()
-        expect = "吾輩は猫である".split(" ")
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)
 
@@ -64,7 +62,7 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
     def test_word_tokenize_with_kytea(self):
         """Test KyTea tokenizer."""
         try:
-            tokenizer = WordTokenizer("kytea")
+            tokenizer = WordTokenizer(tokenizer="kytea")
         except ModuleNotFoundError:
             pytest.skip("skip kytea")
 
@@ -75,7 +73,7 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
     def test_word_tokenize_with_mecab(self):
         """Test MeCab tokenizer."""
         try:
-            tokenizer = WordTokenizer("mecab")
+            tokenizer = WordTokenizer(tokenizer="mecab")
         except ModuleNotFoundError:
             pytest.skip("skip mecab")
 
@@ -86,7 +84,10 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
     def test_word_tokenize_with_sentencepiece(self):
         """Test Sentencepiece tokenizer."""
         try:
-            tokenizer = WordTokenizer("Sentencepiece", "data/model.spm")
+            tokenizer = WordTokenizer(
+                tokenizer="Sentencepiece",
+                model_path="data/model.spm"
+            )
         except ModuleNotFoundError:
             pytest.skip("skip sentencepiece")
 
@@ -96,14 +97,7 @@ class WordTokenizerWithLowerCaseTest(unittest.TestCase):
 
     def test_word_tokenize_with_character(self):
         """Test Character tokenizer."""
-        tokenizer = WordTokenizer("character")
+        tokenizer = WordTokenizer(tokenizer="character")
         expect = "吾 輩 は 猫 で あ る".split(" ")
-        result = tokenizer.tokenize(SENTENCE1)
-        self.assertEqual(expect, result)
-
-    def test_word_without_tokenizer(self):
-        """Test identity tokenizer."""
-        tokenizer = WordTokenizer()
-        expect = "吾輩は猫である".split(" ")
         result = tokenizer.tokenize(SENTENCE1)
         self.assertEqual(expect, result)

--- a/tiny_tokenizer/__init__.py
+++ b/tiny_tokenizer/__init__.py
@@ -2,4 +2,4 @@
 from .sentence_tokenizer import SentenceTokenizer  # NOQA
 from .word_tokenizer import WordTokenizer  # NOQA
 
-__version__ = "1.3.1"
+__version__ = "2.0.0"

--- a/tiny_tokenizer/word_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizer.py
@@ -1,117 +1,209 @@
 """Word Level Tokenizer."""
+from typing import Optional
+
 import warnings
+
+
+class Token:
+    """Token class"""
+    def __init__(
+        self,
+        surface: str,
+        postag: Optional[str] = None
+    ):
+        self.surface = surface
+        self.postag = postag
+
+    def __repr__(self):
+        representation = self.surface
+        if self.postag is not None:
+            representation += f' ({self.postag})'
+        return representation
+
+
+class BaseWordLevelTokenizer:
+    """Base class for word level tokenizer"""
+    def __init__(
+            self,
+            name: str,
+            with_postag: bool = False,
+            **kwargs,
+    ):
+        self.__name = name
+        self.with_postag = with_postag
+
+    def tokenize(self, text: str):
+        """Abstract method for tokenization"""
+        raise NotImplementedError
+
+    @property
+    def name(self):
+        """Return name of tokenizer"""
+        return self.__name
+
+
+class MeCabTokenizer(BaseWordLevelTokenizer):
+    """Wrapper class of external text analyzers"""
+    def __init__(
+        self,
+        dictionary_path: Optional[str] = None,
+        with_postag: bool = False,
+    ):
+        super().__init__(name='mecab', with_postag=with_postag)
+        try:
+            import natto
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("natto-py is not installed")
+
+        flag = ''
+        if not self.with_postag:
+            flag += ' -Owakati'
+
+        if dictionary_path is not None:
+            flag += f' -u {dictionary_path}'
+
+        self.mecab = natto.MeCab(flag)
+
+    def tokenize(self, text: str):
+        """Tokenize"""
+        return_result = []
+        parse_result = self.mecab.parse(text)
+        if self.with_postag:
+            for elem in parse_result.split('\n')[:-1]:
+                surface, feature = elem.split()
+                postag = feature.split(',')[0]
+                return_result.append(Token(surface=surface, postag=postag))
+        else:
+            for surface in parse_result.split(' '):
+                return_result.append(Token(surface=surface))
+
+        return return_result
+
+
+class KyTeaTokenizer(BaseWordLevelTokenizer):
+    """Wrapper class of KyTea"""
+    def __init__(
+        self,
+        with_postag: bool = False,
+        **kwargs,
+    ):
+        super(KyTeaTokenizer, self).__init__(
+            name='kytea',
+            with_postag=with_postag
+        )
+        try:
+            import Mykytea
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("kytea is not installed")
+
+        flag = ''
+        self.kytea = Mykytea.Mykytea(flag)
+
+    def tokenize(self, text: str):
+        return_result = []
+
+        if self.with_postag:
+            for elem in self.kytea.getTagsToString(text).split(' ')[:-1]:
+                surface, postag, _ = elem.split('/')
+                return_result.append(Token(surface=surface, postag=postag))
+
+        else:
+            for surface in list(self.kytea.getWS(text)):
+                return_result.append(Token(surface=surface))
+
+        return return_result
+
+
+class SentencepieceTokenizer(BaseWordLevelTokenizer):
+    """Wrapper class of Sentencepiece"""
+    def __init__(
+        self,
+        model_path: str,
+        **kwargs,
+    ):
+        super(SentencepieceTokenizer, self).__init__('sentencepiece')
+        try:
+            import sentencepiece
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("sentencepiece is not installed")
+
+        self.tokenizer = sentencepiece.SentencePieceProcessor()
+        self.tokenizer.load(model_path)
+
+    def tokenize(self, text: str):
+        return [Token(surface=subword) for subword in
+                self.tokenizer.EncodeAsPieces(text)]
+
+
+class CharacterTokenizer(BaseWordLevelTokenizer):
+    """Character tokenizer"""
+    def __init__(self):
+        super(CharacterTokenizer, self).__init__('character')
+
+    def tokenize(self, text: str):
+        return [Token(surface=char) for char in list(text)]
 
 
 class WordTokenizer:
     """Tokenizer takes a sentence into tokens."""
 
-    def __init__(self, tokenizer=None, flags=""):
+    def __init__(
+        self,
+        tokenizer: Optional[str] = None,
+        with_postag: bool = False,
+        dictionary_path: Optional[str] = None,
+        model_path: Optional[str] = None,
+    ):
         """Create tokenizer.
 
         Keyword Arguments:
             tokenizer {str or None} -- specify the type of tokenizer (default: {None})  # NOQA
             flags {str} -- option passing to tokenizer (default: {''})
         """
-        if tokenizer is None:
-            self.tokenize = self.__identity
-            self.__tokenizer_name = "identity"
-            warnings.warn("No tokenizer specified. Return input directly")
-            return
+        self.__tokenizer_name = tokenizer.lower()
+        self.with_postag = with_postag
+        self.dictionary_path = dictionary_path
+        self.model_path = model_path
 
-        __tokenizer = tokenizer.lower()
+        self.__setup_tokenizer()
 
-        if __tokenizer == "character":
-            self.__tokenizer_name = "Character"
-            self.tokenize = self.__character_level_tokenize
-            return
+    def __setup_tokenizer(self):
+        if self.__tokenizer_name == 'mecab':
+            self.tokenizer = MeCabTokenizer(
+                dictionary_path=self.dictionary_path,
+                with_postag=self.with_postag,
+            )
+        if self.__tokenizer_name == 'kytea':
+            self.tokenizer = KyTeaTokenizer(
+                with_postag=self.with_postag
+            )
+        if self.__tokenizer_name == 'sentencepiece':
+            self.tokenizer = SentencepieceTokenizer(
+                model_path=self.model_path
+            )
+        if self.__tokenizer_name == 'character':
+            self.tokenizer = CharacterTokenizer()
 
-        # use external libraries
-        if __tokenizer == "mecab":
-            try:
-                import natto
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError("natto-py is not installed")
-
-            flags = "-Owakati" if not flags else flags
-            self.__tokenizer = natto.MeCab(flags)
-            self.__tokenizer_name = "MeCab"
-            self.tokenize = self.__mecab_tokenize
-
-        if __tokenizer == "kytea":
-            try:
-                import Mykytea
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError("kytea is not installed")
-
-            self.__tokenizer = Mykytea.Mykytea(flags)
-            self.__tokenizer_name = "KyTea"
-            self.tokenize = self.__kytea_tokenize
-
-        elif __tokenizer == "sentencepiece":
-            try:
-                import sentencepiece
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError("sentencepiece is not installed")
-
-            self.__tokenizer = sentencepiece.SentencePieceProcessor()
-            self.__tokenizer.load(flags)
-            self.__tokenizer_name = "Sentencepiece"
-            self.tokenize = self.__sentencepiece_tokenize
-
-    def __identity(self, sentence):
-        """Return input sentence directly."""
-        return [sentence]
-
-    def __mecab_tokenize(self, sentence):
-        """Mecab tokenizer.
-
-        Arguments:
-            sentence {str} -- raw sentence
-        """
-        return self.__tokenizer.parse(sentence).split(" ")
-
-    def __kytea_tokenize(self, sentence):
-        """Kytea tokenizer.
-
-        Arguments:
-            sentence {str} -- raw sentence
-        """
-        return list(self.__tokenizer.getWS(sentence))
-
-    def __sentencepiece_tokenize(self, sentence):
-        """Sentencepiece tokenizer.
-
-        Arguments:
-            sentence {str} -- raw sentence
-        """
-        return self.__tokenizer.EncodeAsPieces(sentence)
-
-    def __character_level_tokenize(self, sentence):
-        """Character level tokenizer.
-
-        Arguments:
-            sentence {str} -- raw sentence
-        """
-        return list(sentence)
-
-    @property
-    def tokenizer_name(self):
-        return self.__tokenizer_name
+    def tokenize(self, text: str):
+        """Tokenize input text"""
+        return self.tokenizer.tokenize(text)
 
 
 if __name__ == "__main__":
-    word_tokenizer = WordTokenizer("KyTea")
-    res = word_tokenizer.tokenize("我輩は猫である")
-    print(res)
+    tokenizer = WordTokenizer(tokenizer='mecab', with_postag=False)
+    print(tokenizer.tokenize('我輩は猫である'))
 
-    word_tokenizer = WordTokenizer("MeCab")
-    res = word_tokenizer.tokenize("我輩は猫である")
-    print(res)
+    tokenizer = WordTokenizer(tokenizer='mecab', with_postag=True)
+    print(tokenizer.tokenize('我輩は猫である'))
 
-    word_tokenizer = WordTokenizer("Sentencepiece", "data/model.spm")
-    res = word_tokenizer.tokenize("我輩は猫である")
-    print(res)
+    tokenizer = WordTokenizer("kytea", with_postag=False)
+    print(tokenizer.tokenize("我輩は猫である"))
 
-    word_tokenizer = WordTokenizer("Character")
-    res = word_tokenizer.tokenize("我輩は猫である")
-    print(res)
+    tokenizer = WordTokenizer("kytea", with_postag=True)
+    print(tokenizer.tokenize("我輩は猫である"))
+
+    tokenizer = WordTokenizer("sentencepiece", model_path="./data/model.spm")
+    print(tokenizer.tokenize("我輩は猫である"))
+
+    tokenizer = WordTokenizer("character")
+    print(tokenizer.tokenize("我輩は猫である"))

--- a/tiny_tokenizer/word_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizer.py
@@ -192,6 +192,10 @@ class WordTokenizer:
         """Tokenize input text"""
         return self.tokenizer.tokenize(text)
 
+    @property
+    def name(self):
+        return self.__tokenizer_name
+
 
 if __name__ == "__main__":
     tokenizer = WordTokenizer(tokenizer='mecab', with_postag=False)

--- a/tiny_tokenizer/word_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizer.py
@@ -20,6 +20,10 @@ class Token:
             representation += f' ({self.postag})'
         return representation
 
+    def __eq__(self, right):
+        return self.surface == right.surface and \
+            self.postag == right.postag
+
 
 class BaseWordLevelTokenizer:
     """Base class for word level tokenizer"""


### PR DESCRIPTION
I introduce the class `Token` such that we can see part-of-speech tags of parsed results.

```python
tokenizer = WordTokenizer(tokenizer="MeCab", with_postag=True)
print(tokenizer.tokenize(sentence))  # -> `我輩 (名詞), は (助詞), 猫 (名詞), で (助動詞), ある (助動詞), 。 (記号)`
```