### PR TITLE
Fix bug when kytea tokenizer encounter UNK word

### DIFF
--- a/example/tokenize_demo.py
+++ b/example/tokenize_demo.py
@@ -20,7 +20,8 @@ if __name__ == "__main__":
     print("Finish creating word tokenizers")
     print()
 
-    document = "我輩は猫である。名前はまだない"
+    document = "東京特許許可局（とうきょうとっきょきょかきょく） 日本語の早口言葉。"  # NOQA
+    document += "なお実際に特許に関する行政を行うのは特許庁であり、過去にこのような役所が存在したことは一度も無い。"  # NOQA
     print(f"Given document: {document}")
 
     sentences = sentence_tokenizer.tokenize(document)


### PR DESCRIPTION
In the current implementation, tiny_tokenizer fails when the following input is given.

```
input: '東京特許許可局（とうきょうとっきょきょかきょく） 日本語の早口言葉。'

output: '...かきょく/名詞/かきょく ）/補助記号/） /補助記号/UNK 日本/名詞/にっぽん 語/名詞/ご...'
                                          ^^^
```

Double-space breaks WordTokenizer