### PR TITLE
fix some bugs at tokenize_demo.py

### DIFF
--- a/example/tokenize_demo.py
+++ b/example/tokenize_demo.py
@@ -17,21 +17,21 @@ if __name__ == "__main__":
                 _tokenizer = WordTokenizer(tokenizer, with_postag=True)
                 word_tokenizers.append(_tokenizer)
 
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, RuntimeError):
             print("Skip: ", tokenizer)
 
     try:
         _tokenizer = WordTokenizer("Sentencepiece", model_path="./data/model.spm")  # NOQA
         word_tokenizers.append(_tokenizer)
 
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, OSError, RuntimeError):
         print("Skip: ", "Sentencepiece")
 
     try:
         _tokenizer = WordTokenizer("Sudachi", mode="A", with_postag=True)
         word_tokenizers.append(_tokenizer)
 
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, KeyError):
         print("Skip: ", "Sudachi")
 
     print("Finish creating word tokenizers")


### PR DESCRIPTION
85e05e6 fixed import path

16bba8a
When this script is executed in an environment where a specific tokenizer does not exist, `OSError` or `RuntimeError` for tokenizer using `kytea` or `sentencepiece` and `KeyError` for tokenizer using `Sudachi` occurs because there is no `/ user/local/share/kytea/model.bin` etc. before `ModuleNotFoundError`.