### PR TITLE
Add CI job without external libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ before_install:
   - cd kytea-0.4.7 && ./configure && sudo make && sudo make install && cd ..
   - sudo ldconfig -v
 
+env:
+  - PACKAGE_NAME=.[all]
+  - PACKAGE_NAME=.
+
 install:
-  - pip install -e '.[all]'
+  - pip install -e $PACKAGE_NAME
   - pip install https://object-storage.tyo2.conoha.io/v1/nc_2520839e1f9641b08211a5c85243124a/sudachi/SudachiDict_full-20190718.tar.gz
   - sudachipy link -t full
 


### PR DESCRIPTION
I create a job to test tiny_tokenizer where there is no external tokenizer library available.