### PR TITLE
Support token detailed attr

### DIFF
--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,33 +1,29 @@
 """Test for word tokenizers"""
-import unittest
-
 from tiny_tokenizer.tiny_tokenizer_token import Token
 
 
-class TokenTest(unittest.TestCase):
-    """Test ordinal word tokenizer."""
+def test_token_without_feature():
+    token = Token(surface="大崎")
+    assert"大崎" == token.surface
+    assert"" == token.feature
 
-    def test_token_without_feature(self):
-        token = Token(surface="大崎")
-        self.assertEqual("大崎", token.surface)
-        self.assertEqual("", token.feature)
 
-    def test_token_with_postag(self):
-        token = Token(surface="大崎", postag="名詞")
-        self.assertEqual("大崎", token.surface)
-        self.assertEqual("名詞", token.feature)
+def test_token_with_postag():
+    token = Token(surface="大崎", postag="名詞")
+    assert "大崎" == token.surface
+    assert "名詞" == token.feature
 
-    def test_token_with_postag2(self):
-        token = Token(
-            surface="大崎",
-            postag="名詞",
-            postag2="固有名詞,人名,姓",
-            conj_type="*",
-            conj_form="*",
-            origin_form="大崎",
-            yomi="オオサキ",
-            pron="オーサキ")
 
-        self.assertEqual(
-            "名詞,固有名詞,人名,姓,*,*,大崎,オオサキ,オーサキ",
-            token.feature)
+def test_token_with_postag2():
+    token = Token(
+        surface="大崎",
+        postag="名詞",
+        postag2="固有名詞,人名,姓",
+        inflection="*",
+        conjugation="*",
+        origin_form="大崎",
+        yomi="オオサキ",
+        pron="オーサキ")
+
+    truth = "名詞,固有名詞,人名,姓,*,*,大崎,オオサキ,オーサキ"
+    assert token.feature == truth

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -21,7 +21,7 @@ def test_token_with_postag2():
         postag2="固有名詞,人名,姓",
         inflection="*",
         conjugation="*",
-        origin_form="大崎",
+        original_form="大崎",
         yomi="オオサキ",
         pron="オーサキ")
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -21,7 +21,7 @@ def test_token_with_postag2():
         postag2="固有名詞,人名,姓",
         inflection="*",
         conjugation="*",
-        original_form="大崎",
+        base_form="大崎",
         yomi="オオサキ",
         pron="オーサキ")
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -4,8 +4,8 @@ from tiny_tokenizer.tiny_tokenizer_token import Token
 
 def test_token_without_feature():
     token = Token(surface="大崎")
-    assert"大崎" == token.surface
-    assert"" == token.feature
+    assert "大崎" == token.surface
+    assert "" == token.feature
 
 
 def test_token_with_postag():

--- a/tests/word_tokenizer/test_postagging.py
+++ b/tests/word_tokenizer/test_postagging.py
@@ -56,11 +56,11 @@ $ mecab
 EOS
 """
 mecab_tokens_list = [
-    {"surface": "吾輩", "postag": "名詞", "postag1": "代名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
-    {"surface": "は", "postag": "助詞", "postag1": "係助詞", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
-    {"surface": "猫", "postag": "名詞", "postag1": "一般", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
-    {"surface": "で", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "特殊・ダ", "conjugation": "連用形", "original_form": None, "normalized_form": None, "yomi": "デ", "pron": "デ"},  # NOQA
-    {"surface": "ある", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "五段・ラ行アル", "conjugation": "基本形", "original_form": None, "normalized_form": None, "yomi": "アル", "pron": "アル"},  # NOQA
+    {"surface": "吾輩", "postag": "名詞", "postag2": "代名詞", "postag3": "一般", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
+    {"surface": "は", "postag": "助詞", "postag2": "係助詞", "postag3": "*", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
+    {"surface": "猫", "postag": "名詞", "postag2": "一般", "postag3": "*", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
+    {"surface": "で", "postag": "助動詞", "postag2": "*", "postag3": "*", "postag4": "*", "inflection": "特殊・ダ", "conjugation": "連用形", "base_form": None, "normalized_form": None, "yomi": "デ", "pron": "デ"},  # NOQA
+    {"surface": "ある", "postag": "助動詞", "postag2": "*", "postag3": "*", "postag4": "*", "inflection": "五段・ラ行アル", "conjugation": "基本形", "base_form": None, "normalized_form": None, "yomi": "アル", "pron": "アル"},  # NOQA
 ]
 
 
@@ -90,12 +90,12 @@ EOS
                                         norm    dict      yomi
 """
 sudachi_tokens_list = [
-    {"surface": "医薬", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
-    {"surface": "品", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
-    {"surface": "安全", "postag": "名詞", "postag1": "普通名詞", "postag2": "形状詞可能", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
-    {"surface": "管理", "postag": "名詞", "postag1": "普通名詞", "postag2": "サ変可能", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "管理", "normalized_form": "管理", "yomi": "カンリ", "pron": None},  # NOQA
-    {"surface": "責任", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "責任", "normalized_form": "責任", "yomi": "セキニン", "pron": None},  # NOQA
-    {"surface": "者", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "者", "normalized_form": "者", "yomi": "シャ", "pron": None},  # NOQA
+    {"surface": "医薬", "postag": "名詞", "postag2": "普通名詞", "postag3": "一般", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
+    {"surface": "品", "postag": "接尾辞", "postag2": "名詞的", "postag3": "一般", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
+    {"surface": "安全", "postag": "名詞", "postag2": "普通名詞", "postag3": "形状詞可能", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
+    {"surface": "管理", "postag": "名詞", "postag2": "普通名詞", "postag3": "サ変可能", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "管理", "normalized_form": "管理", "yomi": "カンリ", "pron": None},  # NOQA
+    {"surface": "責任", "postag": "名詞", "postag2": "普通名詞", "postag3": "一般", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "責任", "normalized_form": "責任", "yomi": "セキニン", "pron": None},  # NOQA
+    {"surface": "者", "postag": "接尾辞", "postag2": "名詞的", "postag3": "一般", "postag4": "*", "inflection": "*", "conjugation": "*", "base_form": "者", "normalized_form": "者", "yomi": "シャ", "pron": None},  # NOQA
 ]
 
 

--- a/tests/word_tokenizer/test_postagging.py
+++ b/tests/word_tokenizer/test_postagging.py
@@ -56,12 +56,13 @@ $ mecab
 EOS
 """
 list_mecab_tokens = [
-    {"surface": "吾輩", "postag": "名詞", "postag1": "代名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
-    {"surface": "は", "postag": "助詞", "postag1": "係助詞", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
-    {"surface": "猫", "postag": "名詞", "postag1": "一般", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
-    {"surface": "で", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "特殊・ダ", "conjugation": "連用形", "origin_form": None, "normalized_form": None, "yomi": "デ", "pron": "デ"},  # NOQA
-    {"surface": "ある", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "五段・ラ行アル", "conjugation": "基本形", "origin_form": None, "normalized_form": None, "yomi": "アル", "pron": "アル"},  # NOQA
+    {"surface": "吾輩", "postag": "名詞", "postag1": "代名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
+    {"surface": "は", "postag": "助詞", "postag1": "係助詞", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
+    {"surface": "猫", "postag": "名詞", "postag1": "一般", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
+    {"surface": "で", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "特殊・ダ", "conjugation": "連用形", "original_form": None, "normalized_form": None, "yomi": "デ", "pron": "デ"},  # NOQA
+    {"surface": "ある", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "五段・ラ行アル", "conjugation": "基本形", "original_form": None, "normalized_form": None, "yomi": "アル", "pron": "アル"},  # NOQA
 ]
+
 
 def test_word_tokenize_with_mecab():
     """Test MeCab tokenizer."""
@@ -89,12 +90,12 @@ EOS
                                         norm    dict      yomi
 """
 list_sudachi_tokens = [
-    {"surface": "医薬", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
-    {"surface": "品", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
-    {"surface": "安全", "postag": "名詞", "postag1": "普通名詞", "postag2": "形状詞可能", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
-    {"surface": "管理", "postag": "名詞", "postag1": "普通名詞", "postag2": "サ変可能", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "管理", "normalized_form": "管理", "yomi": "カンリ", "pron": None},  # NOQA
-    {"surface": "責任", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "責任", "normalized_form": "責任", "yomi": "セキニン", "pron": None},  # NOQA
-    {"surface": "者", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "者", "normalized_form": "者", "yomi": "シャ", "pron": None},  # NOQA
+    {"surface": "医薬", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
+    {"surface": "品", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
+    {"surface": "安全", "postag": "名詞", "postag1": "普通名詞", "postag2": "形状詞可能", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
+    {"surface": "管理", "postag": "名詞", "postag1": "普通名詞", "postag2": "サ変可能", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "管理", "normalized_form": "管理", "yomi": "カンリ", "pron": None},  # NOQA
+    {"surface": "責任", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "責任", "normalized_form": "責任", "yomi": "セキニン", "pron": None},  # NOQA
+    {"surface": "者", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "者", "normalized_form": "者", "yomi": "シャ", "pron": None},  # NOQA
 ]
 
 

--- a/tests/word_tokenizer/test_postagging.py
+++ b/tests/word_tokenizer/test_postagging.py
@@ -23,7 +23,7 @@ $ kytea
 吾輩は猫である
 吾輩/名詞/わがはい は/助詞/は 猫/名詞/ねこ で/助動詞/で あ/動詞/あ る/語尾/る
 """
-list_kytea_tokens = [
+kytea_tokens_list = [
     {"surface": "吾輩", "postag": "名詞", "pron": "わがはい"},
     {"surface": "は", "postag": "助詞", "pron": "は"},
     {"surface": "猫", "postag": "名詞", "pron": "ねこ"},
@@ -40,7 +40,7 @@ def test_word_tokenize_with_kytea():
     except ModuleNotFoundError:
         pytest.skip("skip kytea")
 
-    expect = [Token(**kwargs) for kwargs in list_kytea_tokens]
+    expect = [Token(**kwargs) for kwargs in kytea_tokens_list]
     result = tokenizer.tokenize(SENTENCE1)
     assert expect == result
 
@@ -55,7 +55,7 @@ $ mecab
 ある    助動詞,*,*,*,五段・ラ行アル,基本形,ある,アル,アル
 EOS
 """
-list_mecab_tokens = [
+mecab_tokens_list = [
     {"surface": "吾輩", "postag": "名詞", "postag1": "代名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
     {"surface": "は", "postag": "助詞", "postag1": "係助詞", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
     {"surface": "猫", "postag": "名詞", "postag1": "一般", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
@@ -71,7 +71,7 @@ def test_word_tokenize_with_mecab():
     except ModuleNotFoundError:
         pytest.skip("skip mecab")
 
-    expect = [Token(**kwargs) for kwargs in list_mecab_tokens]
+    expect = [Token(**kwargs) for kwargs in mecab_tokens_list]
     result = tokenizer.tokenize(SENTENCE1)
     assert expect == result
 
@@ -89,7 +89,7 @@ EOS
                                         ^^^^    ^^^^    ^^^^^^^^
                                         norm    dict      yomi
 """
-list_sudachi_tokens = [
+sudachi_tokens_list = [
     {"surface": "医薬", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
     {"surface": "品", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
     {"surface": "安全", "postag": "名詞", "postag1": "普通名詞", "postag2": "形状詞可能", "postag3": "*", "inflection": "*", "conjugation": "*", "original_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
@@ -107,6 +107,6 @@ def test_word_tokenize_with_sudachi_mode_a():
     except ModuleNotFoundError:
         pytest.skip("skip sudachi")
 
-    expect = [Token(**kwargs) for kwargs in list_sudachi_tokens]
+    expect = [Token(**kwargs) for kwargs in sudachi_tokens_list]
     result = tokenizer.tokenize(SENTENCE2)
     assert expect == result

--- a/tests/word_tokenizer/test_postagging.py
+++ b/tests/word_tokenizer/test_postagging.py
@@ -23,6 +23,14 @@ $ kytea
 吾輩は猫である
 吾輩/名詞/わがはい は/助詞/は 猫/名詞/ねこ で/助動詞/で あ/動詞/あ る/語尾/る
 """
+list_kytea_tokens = [
+    {"surface": "吾輩", "postag": "名詞", "pron": "わがはい"},
+    {"surface": "は", "postag": "助詞", "pron": "は"},
+    {"surface": "猫", "postag": "名詞", "pron": "ねこ"},
+    {"surface": "で", "postag": "助動詞", "pron": "で"},
+    {"surface": "あ", "postag": "動詞", "pron": "あ"},
+    {"surface": "る", "postag": "語尾", "pron": "る"},
+]
 
 
 def test_word_tokenize_with_kytea():
@@ -32,25 +40,28 @@ def test_word_tokenize_with_kytea():
     except ModuleNotFoundError:
         pytest.skip("skip kytea")
 
-    words = "吾輩 は 猫 で あ る".split(" ")  # NOQA
-    postags = "名詞 助詞 名詞 助動詞 動詞 語尾".split(" ")
-
-    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    expect = [Token(**kwargs) for kwargs in list_kytea_tokens]
     result = tokenizer.tokenize(SENTENCE1)
     assert expect == result
 
 
 """
 $ mecab
-我輩は猫である
-我輩    名詞,一般,*,*,*,*,我輩,ワガハイ,ワガハイ
+吾輩は猫である
+吾輩    名詞,一般,*,*,*,*,吾輩,ワガハイ,ワガハイ
 は      助詞,係助詞,*,*,*,*,は,ハ,ワ
 猫      名詞,一般,*,*,*,*,猫,ネコ,ネコ
 で      助動詞,*,*,*,特殊・ダ,連用形,だ,デ,デ
 ある    助動詞,*,*,*,五段・ラ行アル,基本形,ある,アル,アル
 EOS
 """
-
+list_mecab_tokens = [
+    {"surface": "吾輩", "postag": "名詞", "postag1": "代名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ワガハイ", "pron": "ワガハイ"},  # NOQA
+    {"surface": "は", "postag": "助詞", "postag1": "係助詞", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ハ", "pron": "ワ"},  # NOQA
+    {"surface": "猫", "postag": "名詞", "postag1": "一般", "postag2": "*", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": None, "normalized_form": None, "yomi": "ネコ", "pron": "ネコ"},  # NOQA
+    {"surface": "で", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "特殊・ダ", "conjugation": "連用形", "origin_form": None, "normalized_form": None, "yomi": "デ", "pron": "デ"},  # NOQA
+    {"surface": "ある", "postag": "助動詞", "postag1": "*", "postag2": "*", "postag3": "*", "inflection": "五段・ラ行アル", "conjugation": "基本形", "origin_form": None, "normalized_form": None, "yomi": "アル", "pron": "アル"},  # NOQA
+]
 
 def test_word_tokenize_with_mecab():
     """Test MeCab tokenizer."""
@@ -59,25 +70,32 @@ def test_word_tokenize_with_mecab():
     except ModuleNotFoundError:
         pytest.skip("skip mecab")
 
-    words = "吾輩 は 猫 で ある".split(" ")  # NOQA
-    postags = "名詞 助詞 名詞 助動詞 助動詞".split(" ")
-
-    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    expect = [Token(**kwargs) for kwargs in list_mecab_tokens]
     result = tokenizer.tokenize(SENTENCE1)
     assert expect == result
 
 
 """
-$ pipenv run sudachipy tokenize -m A
+$ pipenv run sudachipy tokenize -m A -a
 医薬品安全管理責任者
-医薬    名詞,普通名詞,一般,*,*,*        医薬
-品      接尾辞,名詞的,一般,*,*,*        品
-安全    名詞,普通名詞,形状詞可能,*,*,*  安全
-管理    名詞,普通名詞,サ変可能,*,*,*    管理
-責任    名詞,普通名詞,一般,*,*,*        責任
-者      接尾辞,名詞的,一般,*,*,*        者
+医薬    名詞,普通名詞,一般,*,*,*        医薬    医薬    イヤク  0       (OOV)
+品      接尾辞,名詞的,一般,*,*,*        品      品      ヒン    0       (OOV)
+安全    名詞,普通名詞,形状詞可能,*,*,*  安全    安全    アンゼン        0       (OOV)
+管理    名詞,普通名詞,サ変可能,*,*,*    管理    管理    カンリ  0       (OOV)
+責任    名詞,普通名詞,一般,*,*,*        責任    責任    セキニン        0       (OOV)
+者      接尾辞,名詞的,一般,*,*,*        者      者      シャ    0       (OOV)
 EOS
+                                        ^^^^    ^^^^    ^^^^^^^^
+                                        norm    dict      yomi
 """
+list_sudachi_tokens = [
+    {"surface": "医薬", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "医薬", "normalized_form": "医薬", "yomi": "イヤク", "pron": None},  # NOQA
+    {"surface": "品", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "品", "normalized_form": "品", "yomi": "ヒン", "pron": None},  # NOQA
+    {"surface": "安全", "postag": "名詞", "postag1": "普通名詞", "postag2": "形状詞可能", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "安全", "normalized_form": "安全", "yomi": "アンゼン", "pron": None},  # NOQA
+    {"surface": "管理", "postag": "名詞", "postag1": "普通名詞", "postag2": "サ変可能", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "管理", "normalized_form": "管理", "yomi": "カンリ", "pron": None},  # NOQA
+    {"surface": "責任", "postag": "名詞", "postag1": "普通名詞", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "責任", "normalized_form": "責任", "yomi": "セキニン", "pron": None},  # NOQA
+    {"surface": "者", "postag": "接尾辞", "postag1": "名詞的", "postag2": "一般", "postag3": "*", "inflection": "*", "conjugation": "*", "origin_form": "者", "normalized_form": "者", "yomi": "シャ", "pron": None},  # NOQA
+]
 
 
 def test_word_tokenize_with_sudachi_mode_a():
@@ -88,9 +106,6 @@ def test_word_tokenize_with_sudachi_mode_a():
     except ModuleNotFoundError:
         pytest.skip("skip sudachi")
 
-    words = "医薬 品 安全 管理 責任 者".split(" ")  # NOQA
-    postags = "名詞 接尾辞 名詞 名詞 名詞 接尾辞".split(" ")
-
-    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    expect = [Token(**kwargs) for kwargs in list_sudachi_tokens]
     result = tokenizer.tokenize(SENTENCE2)
     assert expect == result

--- a/tests/word_tokenizer/test_postagging.py
+++ b/tests/word_tokenizer/test_postagging.py
@@ -1,5 +1,13 @@
-"""Test for word tokenizers"""
-import unittest
+"""Test for word tokenizers.
+
+Note that it uses the full version of
+SudachiPy dictionary.
+
+URL is following:
+    'https://object-storage.tyo2.conoha.io/' \
+    'v1/nc_2520839e1f9641b08211a5c85243124a/' \
+    'sudachi/sudachi-dictionary-20190718-full.zip'
+"""
 
 import pytest
 
@@ -10,48 +18,79 @@ SENTENCE1 = "吾輩は猫である"
 SENTENCE2 = "医薬品安全管理責任者"
 
 
-class PostaggingTest(unittest.TestCase):
-    """Test ordinal word tokenizer."""
+"""
+$ kytea
+吾輩は猫である
+吾輩/名詞/わがはい は/助詞/は 猫/名詞/ねこ で/助動詞/で あ/動詞/あ る/語尾/る
+"""
 
-    def test_word_tokenize_with_kytea(self):
-        """Test KyTea tokenizer."""
-        try:
-            tokenizer = WordTokenizer(tokenizer="kytea", with_postag=True)
-        except ModuleNotFoundError:
-            pytest.skip("skip kytea")
 
-        words = "吾輩 は 猫 で あ る".split(" ")  # NOQA
-        postags = "名詞 助詞 名詞 助動詞 動詞 語尾".split(" ")
+def test_word_tokenize_with_kytea():
+    """Test KyTea tokenizer."""
+    try:
+        tokenizer = WordTokenizer(tokenizer="kytea", with_postag=True)
+    except ModuleNotFoundError:
+        pytest.skip("skip kytea")
 
-        expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
-        result = tokenizer.tokenize(SENTENCE1)
-        assert expect == result
+    words = "吾輩 は 猫 で あ る".split(" ")  # NOQA
+    postags = "名詞 助詞 名詞 助動詞 動詞 語尾".split(" ")
 
-    def test_word_tokenize_with_mecab(self):
-        """Test MeCab tokenizer."""
-        try:
-            tokenizer = WordTokenizer(tokenizer="mecab", with_postag=True)
-        except ModuleNotFoundError:
-            pytest.skip("skip mecab")
+    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    result = tokenizer.tokenize(SENTENCE1)
+    assert expect == result
 
-        words = "吾輩 は 猫 で ある".split(" ")  # NOQA
-        postags = "名詞 助詞 名詞 助動詞 助動詞".split(" ")
 
-        expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
-        result = tokenizer.tokenize(SENTENCE1)
-        assert expect == result
+"""
+$ mecab
+我輩は猫である
+我輩    名詞,一般,*,*,*,*,我輩,ワガハイ,ワガハイ
+は      助詞,係助詞,*,*,*,*,は,ハ,ワ
+猫      名詞,一般,*,*,*,*,猫,ネコ,ネコ
+で      助動詞,*,*,*,特殊・ダ,連用形,だ,デ,デ
+ある    助動詞,*,*,*,五段・ラ行アル,基本形,ある,アル,アル
+EOS
+"""
 
-    def test_word_tokenize_with_sudachi_mode_a(self):
-        """Test Sudachi tokenizer."""
-        try:
-            tokenizer = WordTokenizer(
-                tokenizer="sudachi", mode="A", with_postag=True)
-        except ModuleNotFoundError:
-            pytest.skip("skip sudachi")
 
-        words = "医薬 品 安全 管理 責任 者".split(" ")  # NOQA
-        postags = "名詞 接尾辞 名詞 名詞 名詞 接尾辞".split(" ")
+def test_word_tokenize_with_mecab():
+    """Test MeCab tokenizer."""
+    try:
+        tokenizer = WordTokenizer(tokenizer="mecab", with_postag=True)
+    except ModuleNotFoundError:
+        pytest.skip("skip mecab")
 
-        expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
-        result = tokenizer.tokenize(SENTENCE2)
-        self.assertEqual(expect, result)
+    words = "吾輩 は 猫 で ある".split(" ")  # NOQA
+    postags = "名詞 助詞 名詞 助動詞 助動詞".split(" ")
+
+    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    result = tokenizer.tokenize(SENTENCE1)
+    assert expect == result
+
+
+"""
+$ pipenv run sudachipy tokenize -m A
+医薬品安全管理責任者
+医薬    名詞,普通名詞,一般,*,*,*        医薬
+品      接尾辞,名詞的,一般,*,*,*        品
+安全    名詞,普通名詞,形状詞可能,*,*,*  安全
+管理    名詞,普通名詞,サ変可能,*,*,*    管理
+責任    名詞,普通名詞,一般,*,*,*        責任
+者      接尾辞,名詞的,一般,*,*,*        者
+EOS
+"""
+
+
+def test_word_tokenize_with_sudachi_mode_a():
+    """Test Sudachi tokenizer."""
+    try:
+        tokenizer = WordTokenizer(
+            tokenizer="sudachi", mode="A", with_postag=True)
+    except ModuleNotFoundError:
+        pytest.skip("skip sudachi")
+
+    words = "医薬 品 安全 管理 責任 者".split(" ")  # NOQA
+    postags = "名詞 接尾辞 名詞 名詞 名詞 接尾辞".split(" ")
+
+    expect = [Token(surface=w, postag=p) for w, p in zip(words, postags)]
+    result = tokenizer.tokenize(SENTENCE2)
+    assert expect == result

--- a/tiny_tokenizer/tiny_tokenizer_token.py
+++ b/tiny_tokenizer/tiny_tokenizer_token.py
@@ -95,4 +95,6 @@ class Token:
             feature.append(self.yomi)
         if self.pron is not None:
             feature.append(self.pron)
+        if self.normalized_form is not None:
+            feature.append(self.normalized_form)
         return ','.join(feature)

--- a/tiny_tokenizer/tiny_tokenizer_token.py
+++ b/tiny_tokenizer/tiny_tokenizer_token.py
@@ -9,12 +9,12 @@ class Token:
         self,
         surface: str,
         postag: Optional[str] = None,
-        postag1: Optional[str] = None,
         postag2: Optional[str] = None,
         postag3: Optional[str] = None,
+        postag4: Optional[str] = None,
         inflection: Optional[str] = None,
         conjugation: Optional[str] = None,
-        original_form: Optional[str] = None,
+        base_form: Optional[str] = None,
         yomi: Optional[str] = None,
         pron: Optional[str] = None,
         normalized_form: Optional[str] = None,
@@ -28,18 +28,18 @@ class Token:
             surface (original form) of a word
         postag (str, default: None)
             part-of-speech tag of a word (optional)
-        postag1 (str, default: None)
-            detailed part-of-speech tag of a word (optional)
         postag2 (str, default: None)
             detailed part-of-speech tag of a word (optional)
         postag3 (str, default: None)
+            detailed part-of-speech tag of a word (optional)
+        postag4 (str, default: None)
             detailed part-of-speech tag of a word (optional)
         inflection (str, default: None)
             conjugate type of word (optional)
         conjugation (str, default: None)
             conjugate type of word (optional)
-        original_form (str, default: None)
-            original form of a word
+        base_form (str, default: None)
+            base form of a word
         yomi (str, default: None)
             yomi of a word (optional)
         pron (str, default: None)
@@ -51,12 +51,12 @@ class Token:
         """
         self.surface = surface
         self.postag = postag
-        self.postag1 = postag1
         self.postag2 = postag2
         self.postag3 = postag3
+        self.postag4 = postag4
         self.inflection = inflection
         self.conjugation = conjugation
-        self.original_form = original_form
+        self.base_form = base_form
         self.yomi = yomi
         self.pron = pron
         self.normalized_form = normalized_form
@@ -71,7 +71,7 @@ class Token:
         return (
             self.surface == right.surface
             and self.postag == right.postag
-            and self.postag2 == right.postag2
+            and self.postag3 == right.postag3
             and self.yomi == right.yomi)
 
     @property
@@ -79,22 +79,22 @@ class Token:
         feature = []
         if self.postag is not None:
             feature.append(self.postag)
-        if self.postag1 is not None:
-            feature.append(self.postag1)
         if self.postag2 is not None:
             feature.append(self.postag2)
         if self.postag3 is not None:
             feature.append(self.postag3)
+        if self.postag4 is not None:
+            feature.append(self.postag4)
         if self.inflection is not None:
             feature.append(self.inflection)
         if self.conjugation is not None:
             feature.append(self.conjugation)
-        if self.original_form is not None:
-            feature.append(self.original_form)
+        if self.base_form is not None:
+            feature.append(self.base_form)
         if self.yomi is not None:
             feature.append(self.yomi)
         if self.pron is not None:
             feature.append(self.pron)
         if self.normalized_form is not None:
             feature.append(self.normalized_form)
-        return ','.join(feature)
+        return ",".join(feature)

--- a/tiny_tokenizer/tiny_tokenizer_token.py
+++ b/tiny_tokenizer/tiny_tokenizer_token.py
@@ -14,7 +14,7 @@ class Token:
         postag3: Optional[str] = None,
         inflection: Optional[str] = None,
         conjugation: Optional[str] = None,
-        origin_form: Optional[str] = None,
+        original_form: Optional[str] = None,
         yomi: Optional[str] = None,
         pron: Optional[str] = None,
         normalized_form: Optional[str] = None,
@@ -38,7 +38,7 @@ class Token:
             conjugate type of word (optional)
         conjugation (str, default: None)
             conjugate type of word (optional)
-        origin_form (str, default: None)
+        original_form (str, default: None)
             original form of a word
         yomi (str, default: None)
             yomi of a word (optional)
@@ -56,7 +56,7 @@ class Token:
         self.postag3 = postag3
         self.inflection = inflection
         self.conjugation = conjugation
-        self.origin_form = origin_form
+        self.original_form = original_form
         self.pron = pron
         self.yomi = yomi
         self.normalized_form = normalized_form
@@ -89,8 +89,8 @@ class Token:
             feature.append(self.inflection)
         if self.conjugation is not None:
             feature.append(self.conjugation)
-        if self.origin_form is not None:
-            feature.append(self.origin_form)
+        if self.original_form is not None:
+            feature.append(self.original_form)
         if self.yomi is not None:
             feature.append(self.yomi)
         if self.pron is not None:

--- a/tiny_tokenizer/tiny_tokenizer_token.py
+++ b/tiny_tokenizer/tiny_tokenizer_token.py
@@ -57,8 +57,8 @@ class Token:
         self.inflection = inflection
         self.conjugation = conjugation
         self.original_form = original_form
-        self.pron = pron
         self.yomi = yomi
+        self.pron = pron
         self.normalized_form = normalized_form
 
     def __repr__(self):

--- a/tiny_tokenizer/tiny_tokenizer_token.py
+++ b/tiny_tokenizer/tiny_tokenizer_token.py
@@ -9,12 +9,15 @@ class Token:
         self,
         surface: str,
         postag: Optional[str] = None,
+        postag1: Optional[str] = None,
         postag2: Optional[str] = None,
-        conj_type: Optional[str] = None,
-        conj_form: Optional[str] = None,
+        postag3: Optional[str] = None,
+        inflection: Optional[str] = None,
+        conjugation: Optional[str] = None,
         origin_form: Optional[str] = None,
         yomi: Optional[str] = None,
         pron: Optional[str] = None,
+        normalized_form: Optional[str] = None,
     ):
         """
         Initializer for Token.
@@ -25,11 +28,15 @@ class Token:
             surface (original form) of a word
         postag (str, default: None)
             part-of-speech tag of a word (optional)
+        postag1 (str, default: None)
+            detailed part-of-speech tag of a word (optional)
         postag2 (str, default: None)
             detailed part-of-speech tag of a word (optional)
-        conjugate type (str, default: None)
+        postag3 (str, default: None)
+            detailed part-of-speech tag of a word (optional)
+        inflection (str, default: None)
             conjugate type of word (optional)
-        conjugate form (str, default: None)
+        conjugation (str, default: None)
             conjugate type of word (optional)
         origin_form (str, default: None)
             original form of a word
@@ -37,15 +44,22 @@ class Token:
             yomi of a word (optional)
         pron (str, default: None)
             pronounciation of a word (optional)
+        normalized_form (str, default: None)
+            normalized form of a word (optional)
+            Note that normalized_form is only
+            available on SudachiPy
         """
         self.surface = surface
         self.postag = postag
+        self.postag1 = postag1
         self.postag2 = postag2
-        self.conj_type = conj_type
-        self.conj_form = conj_form
+        self.postag3 = postag3
+        self.inflection = inflection
+        self.conjugation = conjugation
         self.origin_form = origin_form
         self.pron = pron
         self.yomi = yomi
+        self.normalized_form = normalized_form
 
     def __repr__(self):
         representation = self.surface
@@ -65,12 +79,16 @@ class Token:
         feature = []
         if self.postag is not None:
             feature.append(self.postag)
+        if self.postag1 is not None:
+            feature.append(self.postag1)
         if self.postag2 is not None:
             feature.append(self.postag2)
-        if self.conj_type is not None:
-            feature.append(self.conj_type)
-        if self.conj_form is not None:
-            feature.append(self.conj_form)
+        if self.postag3 is not None:
+            feature.append(self.postag3)
+        if self.inflection is not None:
+            feature.append(self.inflection)
+        if self.conjugation is not None:
+            feature.append(self.conjugation)
         if self.origin_form is not None:
             feature.append(self.origin_form)
         if self.yomi is not None:

--- a/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
@@ -18,7 +18,7 @@ class KyTeaTokenizer(BaseTokenizer):
         self.kytea = Mykytea.Mykytea(flag)
 
     def tokenize(self, text: str):
-        tokens_list = []
+        tokens = []
 
         if self.with_postag:
             response = self.kytea.getTagsToString(text)
@@ -37,7 +37,7 @@ class KyTeaTokenizer(BaseTokenizer):
                 pron, postag, surface = map(
                     lambda e: e[::-1], elem[::-1].split("/", maxsplit=2))
                 surface = surface.replace("<SPACE>", " ")
-                tokens_list.append(Token(
+                tokens.append(Token(
                     surface=surface,
                     postag=postag,
                     pron=pron
@@ -45,6 +45,6 @@ class KyTeaTokenizer(BaseTokenizer):
 
         else:
             for surface in list(self.kytea.getWS(text)):
-                tokens_list.append(Token(surface=surface))
+                tokens.append(Token(surface=surface))
 
-        return tokens_list
+        return tokens

--- a/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
@@ -18,7 +18,7 @@ class KyTeaTokenizer(BaseTokenizer):
         self.kytea = Mykytea.Mykytea(flag)
 
     def tokenize(self, text: str):
-        list_tokens = []
+        tokens_list = []
 
         if self.with_postag:
             response = self.kytea.getTagsToString(text)
@@ -37,7 +37,7 @@ class KyTeaTokenizer(BaseTokenizer):
                 pron, postag, surface = map(
                     lambda e: e[::-1], elem[::-1].split("/", maxsplit=2))
                 surface = surface.replace("<SPACE>", " ")
-                list_tokens.append(Token(
+                tokens_list.append(Token(
                     surface=surface,
                     postag=postag,
                     pron=pron
@@ -45,6 +45,6 @@ class KyTeaTokenizer(BaseTokenizer):
 
         else:
             for surface in list(self.kytea.getWS(text)):
-                list_tokens.append(Token(surface=surface))
+                tokens_list.append(Token(surface=surface))
 
-        return list_tokens
+        return tokens_list

--- a/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
@@ -22,12 +22,21 @@ class KyTeaTokenizer(BaseTokenizer):
 
         if self.with_postag:
             response = self.kytea.getTagsToString(text)
-            response = response.replace("  ", " <SPACE>")  # FIXME
+            response = response.replace("\\ ", "<SPACE>")  # FIXME "私 は猫"
+            response = response.replace("  ", " <SPACE>")
 
             for elem in response.split(" ")[:-1]:
-                surface, postag, _ = elem.split("/")
+                # FIXME If input contains a character "/",
+                #       KyTea outputs "//補助記号/・",
+                #       which breaks the simple logic elem.split("/")
+                pron, postag, surface = map(
+                    lambda e: e[::-1], elem[::-1].split("/", maxsplit=2))
                 surface = surface.replace("<SPACE>", " ")
-                return_result.append(Token(surface=surface, postag=postag))
+                return_result.append(Token(
+                    surface=surface,
+                    postag=postag,
+                    pron=pron
+                ))
 
         else:
             for surface in list(self.kytea.getWS(text)):

--- a/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
@@ -22,8 +22,13 @@ class KyTeaTokenizer(BaseTokenizer):
 
         if self.with_postag:
             response = self.kytea.getTagsToString(text)
-            response = response.replace("\\ ", "<SPACE>")  # FIXME "私 は猫"
-            response = response.replace("  ", " <SPACE>")
+
+            # FIXME Following dirty workaround is required to
+            #       process inputs which include <whitespace> itself
+            #       (e.g. "私 は猫")
+            response = response \
+                .replace("\\ ", "<SPACE>") \
+                .replace("  ", " <SPACE>")
 
             for elem in response.split(" ")[:-1]:
                 # FIXME If input contains a character "/",

--- a/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/kytea_tokenizer.py
@@ -18,7 +18,7 @@ class KyTeaTokenizer(BaseTokenizer):
         self.kytea = Mykytea.Mykytea(flag)
 
     def tokenize(self, text: str):
-        return_result = []
+        list_tokens = []
 
         if self.with_postag:
             response = self.kytea.getTagsToString(text)
@@ -37,7 +37,7 @@ class KyTeaTokenizer(BaseTokenizer):
                 pron, postag, surface = map(
                     lambda e: e[::-1], elem[::-1].split("/", maxsplit=2))
                 surface = surface.replace("<SPACE>", " ")
-                return_result.append(Token(
+                list_tokens.append(Token(
                     surface=surface,
                     postag=postag,
                     pron=pron
@@ -45,6 +45,6 @@ class KyTeaTokenizer(BaseTokenizer):
 
         else:
             for surface in list(self.kytea.getWS(text)):
-                return_result.append(Token(surface=surface))
+                list_tokens.append(Token(surface=surface))
 
-        return return_result
+        return list_tokens

--- a/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
@@ -43,16 +43,22 @@ class MeCabTokenizer(BaseTokenizer):
         if self.with_postag:
             for elem in parse_result.split("\n")[:-1]:
                 surface, feature = elem.split()
-                postag, postag1, postag2, postag3, \
+                postag, postag2, postag3, postag4, \
                     inflection, conjugation, \
-                    original_form, yomi, pron = feature.split(",")
+                    base_form, *other = feature.split(",")
+
+                # For words not in a dictionary
+                if len(other) == 2:
+                    yomi, pron = other
+                else:
+                    yomi, pron = None, None
 
                 token = Token(
                     surface=surface,
                     postag=postag,
-                    postag1=postag1,
                     postag2=postag2,
                     postag3=postag3,
+                    postag4=postag4,
                     inflection=inflection,
                     conjugation=conjugation,
                     yomi=yomi,

--- a/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
@@ -43,8 +43,21 @@ class MeCabTokenizer(BaseTokenizer):
         if self.with_postag:
             for elem in parse_result.split("\n")[:-1]:
                 surface, feature = elem.split()
-                postag = feature.split(",")[0]
-                return_result.append(Token(surface=surface, postag=postag))
+                postag, postag1, postag2, postag3, \
+                    inflection, conjugation, \
+                    original_form, yomi, pron = feature.split(",")
+
+                token = Token(
+                    surface=surface,
+                    postag=postag,
+                    postag1=postag1,
+                    postag2=postag2,
+                    postag3=postag3,
+                    inflection=inflection,
+                    conjugation=conjugation,
+                    yomi=yomi,
+                    pron=pron)
+                return_result.append(token)
         else:
             for surface in parse_result.split(" "):
                 return_result.append(Token(surface=surface))

--- a/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
@@ -54,7 +54,8 @@ class SudachiTokenizer(BaseTokenizer):
         for token in self.tokenizer.tokenize(text, self.mode):
             surface = token.surface()
             if self.with_postag:
-                postag, postag1, postag2, postag3, *_ = token.part_of_speech()
+                postag, postag1, postag2, postag3, \
+                    inflection, conjugation = token.part_of_speech()
                 origin_form = token.dictionary_form()
                 normalized_form = token.normalized_form()
                 yomi = token.reading_form()
@@ -64,6 +65,8 @@ class SudachiTokenizer(BaseTokenizer):
                     postag1=postag1,
                     postag2=postag2,
                     postag3=postag3,
+                    inflection=inflection,
+                    conjugation=conjugation,
                     origin_form=origin_form,
                     normalized_form=normalized_form,
                     yomi=yomi,

--- a/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
@@ -52,8 +52,25 @@ class SudachiTokenizer(BaseTokenizer):
         """Tokenize."""
         result = []
         for token in self.tokenizer.tokenize(text, self.mode):
-            _token = Token(token.surface())
+            surface = token.surface()
             if self.with_postag:
-                _token.postag = token.part_of_speech()[0]
-            result.append(_token)
+                postag, postag1, postag2, postag3, *_ = token.part_of_speech()
+                origin_form = token.dictionary_form()
+                normalized_form = token.normalized_form()
+                yomi = token.reading_form()
+                result.append(Token(
+                    surface=surface,
+                    postag=postag,
+                    postag1=postag1,
+                    postag2=postag2,
+                    postag3=postag3,
+                    origin_form=origin_form,
+                    normalized_form=normalized_form,
+                    yomi=yomi,
+                ))
+
+            else:
+                result.append(Token(
+                    surface=surface
+                ))
         return result

--- a/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
@@ -56,7 +56,7 @@ class SudachiTokenizer(BaseTokenizer):
             if self.with_postag:
                 postag, postag1, postag2, postag3, \
                     inflection, conjugation = token.part_of_speech()
-                origin_form = token.dictionary_form()
+                original_form = token.dictionary_form()
                 normalized_form = token.normalized_form()
                 yomi = token.reading_form()
                 result.append(Token(
@@ -67,7 +67,7 @@ class SudachiTokenizer(BaseTokenizer):
                     postag3=postag3,
                     inflection=inflection,
                     conjugation=conjugation,
-                    origin_form=origin_form,
+                    original_form=original_form,
                     normalized_form=normalized_form,
                     yomi=yomi,
                 ))

--- a/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/sudachi_tokenizer.py
@@ -54,20 +54,20 @@ class SudachiTokenizer(BaseTokenizer):
         for token in self.tokenizer.tokenize(text, self.mode):
             surface = token.surface()
             if self.with_postag:
-                postag, postag1, postag2, postag3, \
+                postag, postag2, postag3, postag4, \
                     inflection, conjugation = token.part_of_speech()
-                original_form = token.dictionary_form()
+                base_form = token.dictionary_form()
                 normalized_form = token.normalized_form()
                 yomi = token.reading_form()
                 result.append(Token(
                     surface=surface,
                     postag=postag,
-                    postag1=postag1,
                     postag2=postag2,
                     postag3=postag3,
+                    postag4=postag4,
                     inflection=inflection,
                     conjugation=conjugation,
-                    original_form=original_form,
+                    base_form=base_form,
                     normalized_form=normalized_form,
                     yomi=yomi,
                 ))


### PR DESCRIPTION
This PR introduces supports detailed token attributes such as:
- postag1, postag2, postag3: mecab, sudachi
- inflection, conjugation: mecab, sudachi
- origin_form: mecab, sudachi
- yomi: mecab, sudachi
- pronunciation: mecab, kytea
- normalized_form: sudachipy