### PR TITLE
Support system dictionary in MeCab

### DIFF
--- a/tiny_tokenizer/word_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizer.py
@@ -11,7 +11,8 @@ class WordTokenizer:
         self,
         tokenizer: Optional[str] = None,
         with_postag: bool = False,
-        dictionary_path: Optional[str] = None,
+        user_dictionary_path: Optional[str] = None,
+        system_dictionary_path: Optional[str] = None,
         model_path: Optional[str] = None,
         mode: Optional[str] = None,
     ):
@@ -23,7 +24,8 @@ class WordTokenizer:
         """
         self._tokenizer = tokenizer.lower()
         self.with_postag = with_postag
-        self.dictionary_path = dictionary_path
+        self.user_dictionary_path = user_dictionary_path
+        self.system_dictionary_path = system_dictionary_path
         self.model_path = model_path
         if mode is not None:
             self.mode = mode.lower()
@@ -36,18 +38,16 @@ class WordTokenizer:
         if self._tokenizer == "whitespace":
             self.tokenizer = word_tokenizers.WhitespaceTokenizer()
         if self._tokenizer == "kytea":
-            self.tokenizer = word_tokenizers.KyTeaTokenizer(
-                with_postag=self.with_postag)
+            self.tokenizer = word_tokenizers.KyTeaTokenizer(with_postag=self.with_postag)  # NOQA
         if self._tokenizer == "sentencepiece":
-            self.tokenizer = word_tokenizers.SentencepieceTokenizer(
-                model_path=self.model_path)
+            self.tokenizer = word_tokenizers.SentencepieceTokenizer(model_path=self.model_path)  # NOQA
         if self._tokenizer == "mecab":
-            self.tokenizer = word_tokenizers.MeCabTokenizer(
-                dictionary_path=self.dictionary_path,
-                with_postag=self.with_postag)
+            self.tokenizer = word_tokenizers.MeCabTokenizer(user_dictionary_path=self.user_dictionary_path,      # NOQA
+                                                            system_dictionary_path=self.system_dictionary_path,  # NOQA
+                                                            with_postag=self.with_postag)                        # NOQA
         if self._tokenizer == "sudachi":
-            self.tokenizer = word_tokenizers.SudachiTokenizer(
-                mode=self.mode, with_postag=self.with_postag)
+            self.tokenizer = word_tokenizers.SudachiTokenizer(mode=self.mode,
+                                                              with_postag=self.with_postag)  # NOQA
 
     def tokenize(self, text: str):
         """Tokenize input text"""

--- a/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
+++ b/tiny_tokenizer/word_tokenizers/mecab_tokenizer.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from typing import List
 
 from tiny_tokenizer.tiny_tokenizer_token import Token
 from tiny_tokenizer.word_tokenizers.tokenizer import BaseTokenizer
@@ -8,8 +9,11 @@ class MeCabTokenizer(BaseTokenizer):
     """Wrapper class forexternal text analyzers"""
 
     def __init__(
-        self, dictionary_path: Optional[str] = None, with_postag: bool = False
-    ):
+            self,
+            user_dictionary_path: Optional[str] = None,
+            system_dictionary_path: Optional[str] = None,
+            with_postag: bool = False,
+    ) -> None:
         """
         Initializer for MeCabTokenizer.
 
@@ -34,12 +38,15 @@ class MeCabTokenizer(BaseTokenizer):
         if not self.with_postag:
             flag += " -Owakati"
 
-        if dictionary_path is not None:
-            flag += " -u {}".format(dictionary_path)
+        if user_dictionary_path is not None:
+            flag += " -u {}".format(user_dictionary_path)
+
+        if system_dictionary_path is not None:
+            flag += " -d {}".format(system_dictionary_path)
 
         self.mecab = natto.MeCab(flag)
 
-    def tokenize(self, text: str):
+    def tokenize(self, text: str) -> List[Token]:
         """Tokenize"""
         return_result = []
         parse_result = self.mecab.parse(text)


### PR DESCRIPTION
This PR introduces MeCab system dictionary support.
Users can specify their own system dictionaries by following.

```python
WordTokenizer("mecab", system_dictionary_path="...")
```

And, this PR breaks compatibilities.

```python
WordTokenizer("mecab", dictionary_path="...")
```

should be

```python
WordTokenizer("mecab", user_dictionary_path="...")
```